### PR TITLE
Enable Silverstripe v5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4 || ^5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Seems to still work fine in Silverstripe 5, so this PR enables support.