### PR TITLE
Add Silverstripe 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Elvinas Liutkevičius
 
 ## Requirements
 
-SilverStripe 4
+SilverStripe 6
 
 ## Documentation
 

--- a/code/GridField/CopyButton.php
+++ b/code/GridField/CopyButton.php
@@ -7,8 +7,7 @@ use SilverStripe\Forms\GridField\GridField_ColumnProvider;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_FormAction;
 use SilverStripe\Forms\GridField\GridField;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationException;
+use SilverStripe\Core\Validation\ValidationException;
 
 /**
  * This component provides a button for copying record.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4 || ^5"
+        "silverstripe/framework": "^6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updates the module for Silverstripe 6 compatibility.

Summary:
- Updates the Composer Silverstripe framework constraint to `^6`
- Updates the GridField action menu item namespace for Silverstripe 6
- Updates the README requirement note
