### PR TITLE
ci: add dependabot configuration with dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+      production:
+        dependency-type: production
+      dev:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Configure Dependabot for composer and github-actions ecosystems with a weekly update schedule.

### Dependency groups

**Composer:**
- `symfony` — all `symfony/*` packages updated together
- `production` — production dependencies
- `dev` — development dependencies

**GitHub Actions:**
- `actions` — all action dependencies grouped together